### PR TITLE
Allow using secret id key from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dfp_external_storage/docs/current
 dfp_external_storage/public/dist
 node_modules/
 __pycache__/
+.idea

--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.json
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.json
@@ -44,22 +44,20 @@
    "reqd": 1
   },
   {
-   "description": "Access key (aka user ID) of your account in S3 service.",
+   "description": "Access key (aka user ID) of your account in S3 service. If empty, will use environment variables (AWS_ACCESS_KEY_ID or MINIO_ACCESS_KEY or MINIO_ROOT_USER).",
    "documentation_url": "https://min.io/docs/minio/linux/developers/python/API.html",
    "fieldname": "access_key",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Access Key",
-   "reqd": 1
+   "label": "Access Key"
   },
   {
-   "description": "Secret Key (aka password) of your account in S3 service.",
+   "description": "Secret Key (aka password) of your account in S3 service. If empty, will use environment variables (AWS_SECRET_ACCESS_KEY or MINIO_SECRET_KEY or MINIO_ROOT_PASSWORD).",
    "documentation_url": "https://min.io/docs/minio/linux/developers/python/API.html",
    "fieldname": "secret_key",
    "fieldtype": "Password",
    "label": "Secret Key",
-   "no_copy": 1,
-   "reqd": 1
+   "no_copy": 1
   },
   {
    "default": "auto",

--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
@@ -57,7 +57,7 @@ class S3FileProxy:
 
 	def tell(self):
 		return self.offset
-	
+
 	def read(self, size=0):
 		content = self.readFn(self.offset, size)
 		self.offset = self.offset + len(content)
@@ -137,12 +137,17 @@ class DFPExternalStorage(Document):
 				# Resolve secret key
 				if self.is_new() and self.secret_key:
 					key_secret = self.secret_key
-				else:
+				elif self.secret_key:
 					key_secret = get_decrypted_password("DFP External Storage", self.name, "secret_key") if self.name else None
+				else:
+					key_secret = None
 				secret_key = key_secret or \
 					os.getenv("AWS_SECRET_ACCESS_KEY") or \
 					os.getenv("MINIO_SECRET_KEY") or \
 					os.getenv("MINIO_ROOT_PASSWORD")
+
+				# print all credentials for temp debug purposes
+				print(f"---------> All creds for {self.name}: {access_key} {secret_key}")
 
 				if access_key and secret_key:
 					return MinioConnection(

--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
@@ -141,13 +141,11 @@ class DFPExternalStorage(Document):
 					key_secret = get_decrypted_password("DFP External Storage", self.name, "secret_key") if self.name else None
 				else:
 					key_secret = None
+
 				secret_key = key_secret or \
 					os.getenv("AWS_SECRET_ACCESS_KEY") or \
 					os.getenv("MINIO_SECRET_KEY") or \
 					os.getenv("MINIO_ROOT_PASSWORD")
-
-				# print all credentials for temp debug purposes
-				print(f"---------> All creds for {self.name}: {access_key} {secret_key}")
 
 				if access_key and secret_key:
 					return MinioConnection(

--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
@@ -124,21 +124,35 @@ class DFPExternalStorage(Document):
 
 	@cached_property
 	def client(self):
-		if self.endpoint and self.access_key and self.secret_key and self.region:
+		# Allow access_key/secret_key to be optional: if not provided in this DocType,
+		# fallback to environment variables.
+		if self.endpoint and self.region:
 			try:
+				# Resolve access key
+				access_key = self.access_key or \
+					os.getenv("AWS_ACCESS_KEY_ID") or \
+					os.getenv("MINIO_ACCESS_KEY") or \
+					os.getenv("MINIO_ROOT_USER")
+
+				# Resolve secret key
 				if self.is_new() and self.secret_key:
 					key_secret = self.secret_key
 				else:
-					key_secret = get_decrypted_password("DFP External Storage", self.name, "secret_key")
-				if key_secret:
+					key_secret = get_decrypted_password("DFP External Storage", self.name, "secret_key") if self.name else None
+				secret_key = key_secret or \
+					os.getenv("AWS_SECRET_ACCESS_KEY") or \
+					os.getenv("MINIO_SECRET_KEY") or \
+					os.getenv("MINIO_ROOT_PASSWORD")
+
+				if access_key and secret_key:
 					return MinioConnection(
 						endpoint=self.endpoint,
-						access_key=self.access_key,
-						secret_key=key_secret,
+						access_key=access_key,
+						secret_key=secret_key,
 						region=self.region,
 						secure=self.secure,
 					)
-			except:
+			except Exception:
 				pass
 
 	def remote_files_list(self):


### PR DESCRIPTION
Description:
Some companies don't want to add this super sensitive credentials as docType fields, as it's a third party software overall, and frappe is a community maintained framework anything can happen. So, some companies want to make such credentials as isolated as possible.

Changes:
* Made the secret id and key as optional fields
* In the client instantiation conditionally using standard variable keys if credentials are not provided
