### PR TITLE
fix: Replace PageDoesNotExistError with DoesNotExistError

### DIFF
--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
@@ -694,11 +694,14 @@ def file(name:str, file:str):
 	if not response_values:
 		try:
 			doc = frappe.get_doc("File", name)
-			if not doc or not doc.is_downloadable() or doc.file_name != file:
-				raise Exception("File not available")
-		except Exception:
-			# If no document, no read permissions, etc. For security reasons do not give any information, so just raise a 404 error
+		except frappe.DoesNotExistError:
 			raise frappe.PageDoesNotExistError()
+
+		if doc.file_name != file:
+			raise frappe.PageDoesNotExistError()
+
+		if not doc.is_downloadable():
+			raise frappe.PermissionError()
 
 		response_values = {}
 		response_values["headers"] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    # "frappe~=15.0.0" # Installed and managed by bench.
+    "minio"
 ]
 
 [build-system]


### PR DESCRIPTION
**Problem Statement:**
When an unauthorized user attempts to access a file they do not have permission to view, the system incorrectly returns a 404 (Not Found) response instead of a permission-related error. Although the file actually exists, Frappe’s 404 caching mechanism stores this response, causing all subsequent valid requests for that file to also return a cached 404.

**File download security and permission handling:**

* Refactored the `file` function in `dfp_external_storage.py` to:
  - Raise a 404 error (`frappe.PageDoesNotExistError`) if the file document does not exist or the file name does not match.
  - Raise a permission error (`frappe.PermissionError`) if the file exists but is not downloadable.
  - This change improves security by providing clearer and more appropriate error responses for different failure cases.

**Dependency management:**

* Added the `minio` package to the project dependencies in `pyproject.toml`.