### PR TITLE
Fix: Cannot query child DocType directly via frappe.db.get_list

### DIFF
--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.js
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.js
@@ -28,23 +28,24 @@ frappe.ui.form.on('DFP External Storage', {
 			}
 		})
 
-		frappe.db.get_list(
-			'DFP External Storage by Folder',
-			{fields: ['name','folder']}
-		).then(data => {
-			if (data && data.length) {
-				let folders_name_not_assigned = data
-					.filter(d => d.name != frm.doc.name ? d : null)
-					.map(d => d.folder)
-				frm.set_query('folders', function () {
-					return {
-						filters: {
-							is_folder: 1,
-							name: ['not in', folders_name_not_assigned],
-						},
-					}
-				})
-
+		// Fix: Query parent DocType instead of child table to get assigned folders
+		// Child DocTypes (istable=1) cannot be queried directly via frappe.db.get_list
+		frappe.call({
+			method: 'dfp_external_storage.dfp_external_storage.doctype.dfp_external_storage.dfp_external_storage.get_assigned_folders',
+			args: {
+				exclude_storage: frm.doc.name || ''
+			},
+			callback: function(r) {
+				if (r.message && r.message.length) {
+					frm.set_query('folders', function () {
+						return {
+							filters: {
+								is_folder: 1,
+								name: ['not in', r.message],
+							},
+						}
+					})
+				}
 			}
 		})
 

--- a/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
+++ b/dfp_external_storage/dfp_external_storage/doctype/dfp_external_storage/dfp_external_storage.py
@@ -755,3 +755,27 @@ def file(name:str, file:str):
 		return Response(**response_values)
 
 	raise frappe.PageDoesNotExistError()
+
+
+@frappe.whitelist()
+def get_assigned_folders(exclude_storage=None):
+	"""
+	Get list of folders already assigned to any DFP External Storage.
+	This is used to filter out already assigned folders when selecting folders for a storage.
+	
+	Args:
+		exclude_storage: Optional storage name to exclude from the query
+	
+	Returns:
+		List of folder names that are already assigned to other storages
+	"""
+	filters = {}
+	if exclude_storage:
+		filters["parent"] = ["!=", exclude_storage]
+	
+	assigned_folders = frappe.get_all(
+		"DFP External Storage by Folder",
+		filters=filters,
+		pluck="folder"
+	)
+	return assigned_folders


### PR DESCRIPTION
The JavaScript code was trying to query 'DFP External Storage by Folder' directly using frappe.db.get_list(), but child DocTypes (istable=1) cannot be queried directly. This caused the error:
"DFP External Storage by Folder is not a valid parent DocType for DFP External Storage by Folder"

Solution:
- Added a whitelisted Python method `get_assigned_folders()` that queries the child table properly
- Updated JavaScript to use frappe.call() with the new method instead of frappe.db.get_list()

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)